### PR TITLE
README.md and CONTRIBUTING.md Updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,82 +1,33 @@
-# Open Budget: Grand Rapids
+# Open Budget: Grand Rapids Contribution Guide
 
-## 1. Develop Locally
+This document supplies extra information and procedures regarding contributing to Open Budget Grand Rapids.
 
-### Harp
+## Getting Started Contributing
 
-This site is built on Harp using Node.js. That means you can run it locally with minimal setup!
+The easiest way you can make a pull request is by updating the project documentation. Otherwise you should check out the [issues](https://github.com/citizenlabsgr/openbudgetgr/issues) and see if there are any that you would like to work on.
 
-What you'll need:
+If you want to develop on the project's main repository you **must create a development branch**.
 
--  [Node](http://nodejs.org/download/)
--  [Yarn](https://yarnpkg.com/en/)
--  [Harp](http://harpjs.com/)
+For example, if you were working on a feature to classify different budget item types you might name your development branch something like `feature/budget-type-classifications`.
 
+Anything as long as you are **not** developing directly on the `master` branch.
 
-### Install & Run Harp
+If you fork Open Budget Grand Rapids and develop on your own project you do not have to do this.
 
-Once you have the Yarn package manager installed, you can install Harp globally
+## Maintainers
 
-```
-# to install harp for the first time
-yarn global add harp
-```
+Project maintainers have write access to this project are responsible for reviewing and merging all pull requests.
 
-### Create Development Branch
-- Create a development branch from the Citizen Labs master for the [Open Budget project.](https://github.com/citizenlabsgr/openbudgetgr).
+The current maintainers of this project are:
+* [@allen](https://citizenlabs.slack.com/messages/@allen/)
+* Jace B
 
-```
-# To start the Harp server, cd to the _src directory
-cd [repo-location]/_src
-harp server
-```
+It is recommended to reach out to them if you need any help getting started with this project. You can do so through the [Citizen Labs Slack](#getting-help).
 
-This project is coded with:
+## Getting Help
 
-- [jade](http://jade-lang.com/)
-- [Sass](http://sass-lang.com/)
-- [Bootstrap](http://getbootstrap.com/)
-- [React](https://facebook.github.io/react/)
+[Click Here](https://join.slack.com/t/citizenlabs/shared_invite/enQtNTQ0Mjk1NjQ3NjcxLTI0YTRhOWYzZGY4MTBjMWU0NzU0MGY1OTU3Y2YwYTkxZGI2ZTVhMjQwYWEwMWI4NGUwYjI3OTE3Y2NlNTdhNzU) to join us on Slack.
 
+Maintainers and contributors that work on this project are located in the [Citizen Labs](https://citizenlabs.org/) Slack workspace.
 
-## 2. Creating & Editing Pages
-
-- All development activity occurs in `_src/`. The root folder is only for compiled output for deployment.
-- Page content is inserted into the `layout.jade` file (which includes basic header and footer snippets)
-- Create your `.jade` file
-- Add a link to the main nav in the appropriate place
-- Add relevant metadata in `_data.json` (page title, page slug (url), ...)
-- If your page uses custom page-specific css, add it to a new `.scss` partial and import it into the main stylesheet. (Make sure to namespace it the same way the others are.)
-
-## 3. Instructions for "Flow" Diagram Pages
-
-1. Flow pages are built off a template; copy one of the `*-budget-flow.jade` pages and update the content blocks as necessary.
-1. Data files must be placed in the `data/flow` directory. Follow the naming convention seen there or your files won't load properly. **Note: Two underscores required in data file name, ex: FY17__final.csv.** You also will need to point your page at the appropriate files as seen in the `get_datafiles` content block.
-1. the following columns are required in your datafile and their names should be normalized as seen here. Other columns should be removed to minimize the data download.
-    - budget_year
-    - department
-    - fund_code
-    - account_type (this should be the Expense/Revenue column, if there are duplicate names)
-    - account_category
-    - amount
-
-## 4. Instructions for "Treemap" Diagram Pages
-
-1. Treemap pages are built off a template; copy one of the `*-budget-tree.jade` pages and update the content blocks as necessary.
-1. Instructions for generating the necessary data files can be found [here](_treemap/README.md). Add them to the `data/tree/` directory following the naming convention seen in the existing files.
-1. Json files should follow this naming convention, Status (Final, Preliminary, Proposed, etc).Acount Type (Revenue or Expense).Budget Year.json. Examples: `Final.Expense.FY19.json` and `Final.Revenue.FY19.json`
-1. Update the `datafiles` content block with the appropriate metadata and file path for the data files you generated.
-
-## 5. Instructions for "Compare" page
-
-1. The Compare page is mainly powered by a React application. The source files are in `_src/js/compare/` and are are bundled with [Webpack](https://webpack.js.org/).
-1. When developing on the Compare page, run `yarn` to install all the necessary node dependencies and `yarn run watch` to watch the source files for changes and rebuild the asset bundles accordingly.
-1. The Compare page communicates with a separately maintained API to fetch its data. Documentation for that API can be found [in our wiki](https://github.com/openoakland/openbudgetoakland/wiki/API-Documentation).
-
-## 6. Creating/Updating Budget Timeline
-The timeline is made using [TimelineJS](http://timeline.knightlab.com), an open-source tool that enables anyone to build visually rich, interactive timelines. Beginners can create a timeline using nothing more than a Google spreadsheet, like the one we used for the Timeline above. Experts can use their JSON skills to create custom installations, while keeping TimelineJS's core functionality.
-
-The Google spreadsheet for the current [Budget Timeline used for Grand Rapids](https://grbudget.citizenlabs.org/budget-process.html) is a Citizen Labs' shared Google Sheet, can be [viewed here.](https://docs.google.com/spreadsheets/d/1jL2_7lJSgbLchJfAGWrST16ZxKe5Z-vbOfrAu14QyG8/edit?usp=sharing)
-
-## 7. Publishing Changes
-Make changes on your personal fork or branch. If you have repo access, and your changes are ready for review, you can merge them into the development branch and publish to the staging site for review. You can also publish changes to your own server and merge to development afterwards.
+The Open Budget Grand Rapids specific Slack channel is `#project-openbudgetgr`

--- a/README.md
+++ b/README.md
@@ -15,17 +15,25 @@ These next items listed are necessary to develop this project on your local mach
 
 #### Yarn
 
-This project uses Yarn package manager to install dependencies. Go to the [Yarn website](https://yarnpkg.com/) in order to learn how to install it.
+This project uses Yarn package manager to install dependencies.
+
+You can install Yarn on mac using the command below or by going to the [Yarn website](https://yarnpkg.com/).
+
+```
+brew install yarn
+```
 
 #### Harp
 
-This site is built with the [Harp static site generator](http://harpjs.com/). Harp can be used to develop on the site locally with minimal setup.
+This site is built with the [Harp static site generator](http://harpjs.com/).
 
 To install Harp globally, make sure you have `yarn` package manager installed, and then use the following commands
 
 ```sh
 yarn global add harp
 ```
+
+Harp was partially created to be a development tool for static sites, and includes minimal setup to start developing on the site locally
 
 ### Development
 
@@ -44,29 +52,55 @@ yarn install
 harp server
 ```
 
+## Documentation
+
+### Creating & Editing Pages
+
+- Page content is inserted into the `layout.jade` file (which includes basic header and footer snippets)
+- Create your `.jade` file
+- Add a link to the main nav in the appropriate place
+- Add relevant metadata in `_data.json` (page title, page slug (url), ...)
+- If your page uses custom page-specific css, add it to a new `.scss` partial and import it into the main stylesheet. (Make sure to namespace it the same way the others are.)
+
+### Instructions for "Flow" Diagram Pages
+
+* Flow pages are built off a template; copy one of the `*-budget-flow.jade` pages and update the content blocks as necessary.
+* Data files must be placed in the `data/flow` directory. Follow the naming convention seen there or your files won't load properly. **Note: Two underscores required in data file name, ex: FY17__final.csv.** You also will need to point your page at the appropriate files as seen in the `get_datafiles` content block.
+* The following columns are required in your datafile and their names should be normalized as seen here. Other columns should be removed to minimize the data download.
+    - budget_year
+    - department
+    - fund_code
+    - account_type (this should be the Expense/Revenue column, if there are duplicate names)
+    - account_category
+    - amount
+
+### Instructions for "Treemap" Diagram Pages
+
+* Treemap pages are built off a template; copy one of the `*-budget-tree.jade` pages and update the content blocks as necessary.
+* Instructions for generating the necessary data files can be found [here](_treemap/README.md). Add them to the `data/tree/` directory following the naming convention seen in the existing files.
+* Json files should follow this naming convention, Status (Final, Preliminary, Proposed, etc).Acount Type (Revenue or Expense).Budget Year.json. Examples: `Final.Expense.FY19.json` and `Final.Revenue.FY19.json`
+* Update the `datafiles` content block with the appropriate metadata and file path for the data files you generated.
+
+### Instructions for "Compare" page
+
+* The Compare page is mainly powered by a React application. The source files are in `_src/js/compare/` and are are bundled with [Webpack](https://webpack.js.org/).
+* When developing on the Compare page, run `yarn` to install all the necessary node dependencies and `yarn run watch` to watch the source files for changes and rebuild the asset bundles accordingly.
+* The Compare page communicates with a separately maintained API to fetch its data. Documentation for that API can be found [in our wiki](https://github.com/openoakland/openbudgetoakland/wiki/API-Documentation).
+
+### Creating/Updating Budget Timeline
+The timeline is made using [TimelineJS](http://timeline.knightlab.com), an open-source tool that enables anyone to build visually rich, interactive timelines. Beginners can create a timeline using nothing more than a Google spreadsheet, like the one we used for the Timeline above. Experts can use their JSON skills to create custom installations, while keeping TimelineJS's core functionality.
+
+The Google spreadsheet for the current [Budget Timeline used for Grand Rapids](https://grbudget.citizenlabs.org/budget-process.html) is a Citizen Labs' shared Google Sheet, can be [viewed here.](https://docs.google.com/spreadsheets/d/1jL2_7lJSgbLchJfAGWrST16ZxKe5Z-vbOfrAu14QyG8/edit?usp=sharing)
+
+### Publishing Changes
+Make changes on your personal fork or branch. If you have repo access, and your changes are ready for review, you can merge them into the development branch and publish to the staging site for review. You can also publish changes to your own server and merge to development afterwards.
+
 ## Contributing
 
-Before making any changes please consider reading the [Contribution Guide](./CONTRIBUTING.md). This document sets a guideline for how to best contribute to parts of the OpenBudget GR project.
+Before making your first contribution to this project, please read the [Contribution Guide](./CONTRIBUTING.md)
 
-The easiest way you can make a pull request is by making changes to the documentation or README files. Otherwise you should check out the [issues](https://github.com/citizenlabsgr/openbudgetgr/issues) and see if there are any that you can work on.
 
-### Maintainers
-
-Project maintainers have write access to this project are responsible for reviewing and merging all pull requests.
-
-The current maintainers of this project are:
-* [@allen](https://citizenlabs.slack.com/messages/@allen/)
-* Jace B
-
-It is recommended to reach out to them if you need any help getting started with this project. They can be found on the [CitizenLabs Slack](#slack)
-
-Updates to documentation or the [README](/README.md) make for a great first pull request.
-
-### Slack
-
-You can talk with Citizen Labs and the maintainers of this project through [Slack](https://join.slack.com/t/citizenlabs/shared_invite/enQtNTQ0Mjk1NjQ3NjcxLTI0YTRhOWYzZGY4MTBjMWU0NzU0MGY1OTU3Y2YwYTkxZGI2ZTVhMjQwYWEwMWI4NGUwYjI3OTE3Y2NlNTdhNzU). The specific channel name for this project is `#project-openbudgetgr`
-
-## Data
+## Data Sources
 
 City of Grand Rapids, [MI Data Portal](https://www.grandrapidsmi.gov/GRData)
 
@@ -83,6 +117,7 @@ City of Grand Rapids, [MI Data Portal](https://www.grandrapidsmi.gov/GRData)
 - [React](https://reactjs.org/)
 - [Yarn](https://yarnpkg.com/en/)
 - [Chartjs](https://www.chartjs.org/)
+- [TimelineJS](http://timeline.knightlab.com)
 
 ## Skills
 - Documentation

--- a/README.md
+++ b/README.md
@@ -88,11 +88,13 @@ harp server
 * The Compare page communicates with a separately maintained API to fetch its data. Documentation for that API can be found [in our wiki](https://github.com/openoakland/openbudgetoakland/wiki/API-Documentation).
 
 ### Creating/Updating Budget Timeline
+
 The timeline is made using [TimelineJS](http://timeline.knightlab.com), an open-source tool that enables anyone to build visually rich, interactive timelines. Beginners can create a timeline using nothing more than a Google spreadsheet, like the one we used for the Timeline above. Experts can use their JSON skills to create custom installations, while keeping TimelineJS's core functionality.
 
 The Google spreadsheet for the current [Budget Timeline used for Grand Rapids](https://grbudget.citizenlabs.org/budget-process.html) is a Citizen Labs' shared Google Sheet, can be [viewed here.](https://docs.google.com/spreadsheets/d/1jL2_7lJSgbLchJfAGWrST16ZxKe5Z-vbOfrAu14QyG8/edit?usp=sharing)
 
 ### Publishing Changes
+
 Make changes on your personal fork or branch. If you have repo access, and your changes are ready for review, you can merge them into the development branch and publish to the staging site for review. You can also publish changes to your own server and merge to development afterwards.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Harp was partially created to be a development tool for static sites, and includ
 
 The [`/src`](./_src) directory is the working folder of this project, and contains all necessary code that is compiled in the static site.
 
-To start development of this project, make sure that you have all of the [prerequisites](#prerequisites), and run the the following commands
+To start developing, make sure you have all [prerequisites](#prerequisites) installed, and run the the following commands
 
 ```sh
 # Go to the '_src' folder of the OpenBudget GR project
@@ -52,7 +52,11 @@ yarn install
 harp server
 ```
 
+The Harp server should tell you where to point your browser. Once you do that you should see the Open Budget Grand Rapids project that you can activey develop on.
+
 ## Documentation
+
+Do not be afraid of updating the documentation if there is anyting that should be changed. Also please add to this documentation when a new feature is implemented.
 
 ### Creating & Editing Pages
 

--- a/README.md
+++ b/README.md
@@ -7,43 +7,48 @@ Open Budget Grand Rapids intends to promote a deeper understanding of the City o
 
 ## Getting Started
 
+Use the following documentation to help you get started developing with this project.
+
 ### Prerequisites
 
-This project was developed with Harpjs
+These next items listed are necessary to develop this project on your local machine.
 
-**Slack:** #project-openbudgetgr
+#### Yarn
 
-**Project Description:**
+This project uses Yarn package manager to install dependencies. Go to the [Yarn website](https://yarnpkg.com/) in order to learn how to install it.
 
+#### Harp
 
+This site is built with the [Harp static site generator](http://harpjs.com/). Harp can be used to develop on the site locally with minimal setup.
+
+To install Harp globally, make sure you have `yarn` package manager installed, and then use the following commands
+
+```sh
+yarn global add harp
 ```
-# To start the Harp server, cd to the _src directory
+
+### Development
+
+The [`/src`](./_src) directory is the working folder of this project, and contains all necessary code that is compiled in the static site.
+
+To start development of this project, make sure that you have all of the [prerequisites](#prerequisites), and run the the following commands
+
+```sh
+# Go to the '_src' folder of the OpenBudget GR project
 cd [repo-location]/_src
+
+# Install required project dependencies
+yarn install
+
+# Run harp development server
 harp server
 ```
 
-This project is coded with:
-
-
-
-**Project Guide:**  [@allen](https://citizenlabs.slack.com/messages/@allen/)
-
-**Maintainers (people with write access):**
-* [@allen](https://citizenlabs.slack.com/messages/@allen/)
-* Jace B
-
-**Data:**
-
-City of Grand Rapids, [MI Data Portal](https://www.grandrapidsmi.gov/GRData)
-
-- [FY2017 Data](https://data.world/citizenlabs/city-of-grand-rapids-fy-2017-budget)
-- [FY2018 Data](https://data.world/citizenlabs/city-of-grand-rapids-fy-2018-budget)
-
 ## Contributing
 
-Before making any changes please consider reading the [Contribution Guide](./CONTRIBUTING.md). This document has information regarding parts of this project that can be maintained.
+Before making any changes please consider reading the [Contribution Guide](./CONTRIBUTING.md). This document sets a guideline for how to best contribute to parts of the OpenBudget GR project.
 
-The easiest ways to make a pull request are by making updates to the README or by browsing the issues.
+The easiest way you can make a pull request is by making changes to the documentation or README files. Otherwise you should check out the [issues](https://github.com/citizenlabsgr/openbudgetgr/issues) and see if there are any that you can work on.
 
 ### Maintainers
 
@@ -56,6 +61,17 @@ The current maintainers of this project are:
 It is recommended to reach out to them if you need any help getting started with this project. They can be found on the [CitizenLabs Slack](#slack)
 
 Updates to documentation or the [README](/README.md) make for a great first pull request.
+
+### Slack
+
+You can talk with Citizen Labs and the maintainers of this project through [Slack](https://join.slack.com/t/citizenlabs/shared_invite/enQtNTQ0Mjk1NjQ3NjcxLTI0YTRhOWYzZGY4MTBjMWU0NzU0MGY1OTU3Y2YwYTkxZGI2ZTVhMjQwYWEwMWI4NGUwYjI3OTE3Y2NlNTdhNzU). The specific channel name for this project is `#project-openbudgetgr`
+
+## Data
+
+City of Grand Rapids, [MI Data Portal](https://www.grandrapidsmi.gov/GRData)
+
+- [FY2017 Data](https://data.world/citizenlabs/city-of-grand-rapids-fy-2017-budget)
+- [FY2018 Data](https://data.world/citizenlabs/city-of-grand-rapids-fy-2018-budget)
 
 ## Built With
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,28 @@
 
 # Open Budget Grand Rapids
 
+Open Budget Grand Rapids intends to promote a deeper understanding of the City of Grand Rapids Budget. We believe that this project will allow citizens, officials, and other stakeholders to engage in more informed dialogue about how the City of Grand Rapids currently works and how it should in the future.
+
+## Getting Started
+
+### Prerequisites
+
+This project was developed with Harpjs
+
 **Slack:** #project-openbudgetgr
 
 **Project Description:**
-We are developing a way to better understand the budget process for the City of Grand Rapids. This is the follow-up to the initial 2016 release of [openbudgetgr.org](http://openbudgetgr.org). The site is now current with FY2018 data.
 
-Our Open Budget project intends to promotes a deeper understanding of the city budget, so that citizens, officials, and other stakeholders can engage in more informed dialogue about how the City of Grand Rapids currently works and how it should in the future.
 
-The Open Budget website is built using Node.js. During development the project is run locally on a computer. After acquiring and formatting the budget data properly you publish the website using Harp to compile the static files necessary for a Github posted website.
+```
+# To start the Harp server, cd to the _src directory
+cd [repo-location]/_src
+harp server
+```
+
+This project is coded with:
+
+
 
 **Project Guide:**  [@allen](https://citizenlabs.slack.com/messages/@allen/)
 
@@ -25,20 +39,39 @@ City of Grand Rapids, [MI Data Portal](https://www.grandrapidsmi.gov/GRData)
 - [FY2017 Data](https://data.world/citizenlabs/city-of-grand-rapids-fy-2017-budget)
 - [FY2018 Data](https://data.world/citizenlabs/city-of-grand-rapids-fy-2018-budget)
 
-### Getting started:
-* Browse our help wanted issues. See if there is anything that interests you.
-* Core maintainers and project guides are responsible for reviewing and merging all pull requests. In order to prevent frustrations with your first PR we recommend you reach out to our core maintainers who can help you through your first PR.
-* Updates to documentation or readme are greatly appreciated and make for a great first PR. They do not need to be discussed in advance and will be merged as soon as possible.
+## Contributing
 
+Before making any changes please consider reading the [Contribution Guide](./CONTRIBUTING.md). This document has information regarding parts of this project that can be maintained.
 
-### Skills
+The easiest ways to make a pull request are by making updates to the README or by browsing the issues.
+
+### Maintainers
+
+Project maintainers have write access to this project are responsible for reviewing and merging all pull requests.
+
+The current maintainers of this project are:
+* [@allen](https://citizenlabs.slack.com/messages/@allen/)
+* Jace B
+
+It is recommended to reach out to them if you need any help getting started with this project. They can be found on the [CitizenLabs Slack](#slack)
+
+Updates to documentation or the [README](/README.md) make for a great first pull request.
+
+## Built With
+
+- [Node](https://nodejs.org/en/)
+- [Harp](http://harpjs.com/)
+- [Jade](https://jade-lang.com/)
+- [Sass](https://sass-lang.com/)
+- [Bootstrap](https://getbootstrap.com/)
+- [React](https://reactjs.org/)
+- [Yarn](https://yarnpkg.com/en/)
+- [Chartjs](https://www.chartjs.org/)
+
+## Skills
 - Documentation
 - Data collection
 - Data visualization
 - Civic Engagement
 - Design
 - Javascript
-- Jade
-- Sass
-- Bootstrap
-- React


### PR DESCRIPTION
These changes are based off of what I would

### CONTRIBUTING.md Updates

CONTRIBUTING.md is updated with the goal of expressing contributing guidelines. 

Changes:
* Moved Project documentation to README
* Moved Installation and "Getting Started" guidelines to README

### README.md updates

Since the README is the first item people see in a repo, it makes sense to put the most important information in it. Some of these changes are based on items that I wish I saw when I first went through the process of installing and running this project.

Changes:
* Added Documentation section
* Added getting started section - Includes installation and commands to use to get project started
* Explicitly stated that project files are in the `_src/` directory 
