### PR TITLE
Modifying tools-projects.jade

### DIFF
--- a/_src/tools-projects.jade
+++ b/_src/tools-projects.jade
@@ -1,84 +1,77 @@
 .container
-
   .row
     .col-md-9
-      div
-        h2.subheader Tools and Projects
-        p
-          | Here are resources that have helped or inspired our work so far. Soon, we'll relaunch this page as a wiki so people can more easily contribute. For now,
-          a(href='contact.html') send us links
-          | . As you explore the list below and see how others are making budgets more accessible, feel free to
-          a(href='feedback.html') suggest features
-          |  for Open Budget.
-        h3.subheader
-          | Budget visualization resources
-        ul.disc
+      h1 Tools and Projects
+      p Here are resources that have helped or inspired our work so far. Soon, we'll relaunch this page as a wiki so people can more easily contribute.
+      p For now, #[a(href='contact.html') send us links]. As you explore the list below and see how others are making budgets more accessible, feel free to #[a(href='feedback.html') suggest features] for Open Budget.
+      h2 Budget Visualization Resources
+      p The items listed below are resources used to create the budget data visualizations that are seen here in Open Budget Grand Rapids
+      ul.disc
+        li
+          a(href='http://openspending.org', target='_blank') OpenSpending:
+          |  OpenSpending is a free, open and global platform to search, visualise and analyse fiscal data in the public sphere.
+        li
+          a(href='http://d3js.org/', target='_blank') D3:
+          |  D3.js is a JavaScript library for manipulating documents based on data. D3 helps you bring data to life using HTML, SVG, and CSS. D3’s emphasis on web standards gives you the full capabilities of modern browsers without tying yourself to a proprietary framework, combining powerful visualization components and a data-driven approach to DOM manipulation.
+        li
+          a(href='http://www.peterkrantz.com/2012/data-visualization-tools/', target='_blank') Peter Krantz:
+          |  Author of some of the base code used for this budget visualization project.
+        li
+          a(href='http://vallandingham.me/vis/', target='_blank') Jim Vallandingham:
+          |  Author of some of the base code used for this budget visualization project.
+      h2 Budget Data Resources
+      ul.disc
+        li
+          a(href='http://openspending.org/resources/handbook/ch001_introduction.html', target='_blank') Spending Data Handbook
+        li
+          a(href='http://openspending.org/resources/standard/', target='_blank') A data standard for transaction-level spending data
+      h2 Budget Visualization Examples
+      p The resources listed below consist of example locations that have done budget visualization exercises. We used these examples to consider what could be done with Open Budget Grand Rapids.
+      h3 Cities
+      ul.disc
+        li
+          a(href='http://www.comptroller.nyc.gov/mymoneynyc/', target='_blank') My Money NYC
+        li
+          a(href='http://www.checkbooknyc.com/', target='_blank') Checkbook NYC
+        li
+          a(href='http://paloalto.delphi.us', target='_blank') Palo Alto
+        li
+          a(href='http://www.interislandterminal.org/assets/scripts/viz/hnlbudget/sankey.html', target='_blank') Honolulu
+        li
+          a(href='http://www.berlin.de/sen/finanzen/haushalt/haushaltsplan/artikel.5697.php', target='_blank') Berlin
+        li
+          a(href='http://budget.brettmandel.com', target='_blank') Philadelphia
+        li
+          a(href='http://longbeach.budgetchallenge.org/pages/overview', target='_blank') Long Beach
+      h3 Counties
+      ul.disc
+        li
+          a(href='http://lookatcook.com/', target='_blank') Look at Cook
+      h3 States
+      ul.disc
+        li
+          a(href='http://www.budgetchallenge.org/', target='_blank') California Budget Challenge
+        li
+          a(href='http://demo.outline.com/#budget/2', target='_blank') Massachusetts Budget Simulator
+        li
+          a(href='http://www.ofm.wa.gov/budget13/visualization/default.asp', target='_blank') Washington Governor's Proposed 2013-15 Budget
+      h3 Countries
+      ul.disc
+        li
+          a(href='http://philogb.github.io/budgetvis/', target='_blank') US Budget spending 2011 (US)
+        li
+          a(href='http://wheredidmytaxdollarsgo.com/', target='_blank') Where Did My Tax Dollars Go? (US)
+        li
+          a(href='http://www.nytimes.com/interactive/2012/02/13/us/politics/2013-budget-proposal-graphic.html?_r=0', target='_blank') Obama’s 2013 Budget Proposal
           li
-            a(href='http://www.openspending.org', target='_blank') OpenSpending:
-            |  OpenSpending is a free, open and global platform to search, visualise and analyse fiscal data in the public sphere.
+            a(href='http://wheredoesmymoneygo.org/', target='_blank') Where Does My Money Go? (UK)
           li
-            a(href='http://d3js.org/', target='_blank') D3:
-            |  D3.js is a JavaScript library for manipulating documents based on data. D3 helps you bring data to life using HTML, SVG, and CSS. D3’s emphasis on web standards gives you the full capabilities of modern browsers without tying yourself to a proprietary framework, combining powerful visualization components and a data-driven approach to DOM manipulation.
+            a(href='http://peterkrantz.com/v11n/statsbudget-2013/', target='_blank') Statsbudgeten 2013 (Sweden)
           li
-            a(href='http://www.peterkrantz.com/2012/data-visualization-tools/', target='_blank') Peter Krantz:
-            |  Author of some of the base code used for this budget visualization project.
+            a(href='http://bund.offenerhaushalt.de/', target='_blank') OffenerHaushalt.de (Germany)
           li
-            a(href='http://vallandingham.me/vis/', target='_blank') Jim Vallandingham:
-            |  Author of some of the base code used for this budget visualization project.
-        h3.subheader
-          | Budget data resources
-        ul.disc
+            a(href='http://cameroon.openspending.org', target='_blank') Cameroon Budget Inquirer
           li
-            a(href='http://openspending.org/resources/handbook/ch001_introduction.html', target='_blank') Spending Data Handbook
+            a(href='http://slovakia.openspending.org', target='_blank') Slovakia's Municipal Budgets
           li
-            a(href='http://openspending.org/resources/standard/', target='_blank') A data standard for transaction-level spending data
-        h3.subheader
-          | Budget visualization examples
-        h4.subheader Cities
-        ul.disc
-          li
-            a(href='http://www.comptroller.nyc.gov/mymoneynyc/', target='_blank') My Money NYC
-          li
-            a(href='http://www.checkbooknyc.com/', target='_blank') Checkbook NYC
-          li
-            a(href='http://paloalto.delphi.us', target='_blank') Palo Alto
-          li
-            a(href='http://www.interislandterminal.org/assets/scripts/viz/hnlbudget/sankey.html', target='_blank') Honolulu
-          li
-            a(href='http://www.berlin.de/sen/finanzen/haushalt/haushaltsplan/artikel.5697.php', target='_blank') Berlin
-          li
-            a(href='http://budget.brettmandel.com', target='_blank') Philadelphia
-          li
-            a(href='http://longbeach.budgetchallenge.org/pages/overview', target='_blank') Long Beach
-        h4.subheader Counties
-        ul.disc
-          li
-            a(href='http://lookatcook.com/', target='_blank') Look at Cook
-        h4.subheader States
-        ul.disc
-          li
-            a(href='http://www.budgetchallenge.org/', target='_blank') California Budget Challenge
-          li
-            a(href='http://demo.outline.com/#budget/2', target='_blank') Massachusetts Budget Simulator
-          li
-            a(href='http://www.ofm.wa.gov/budget13/visualization/default.asp', target='_blank') Washington Governor's Proposed 2013-15 Budget
-        h4.subheader Countries
-        ul.disc
-          li
-            a(href='http://philogb.github.io/budgetvis/', target='_blank') US Budget spending 2011 (US)
-          li
-            a(href='http://wheredidmytaxdollarsgo.com/', target='_blank') Where Did My Tax Dollars Go? (US)
-          li
-            a(href='http://www.nytimes.com/interactive/2012/02/13/us/politics/2013-budget-proposal-graphic.html?_r=0', target='_blank') Obama’s 2013 Budget Proposal
-            li
-              a(href='http://wheredoesmymoneygo.org/', target='_blank') Where Does My Money Go? (UK)
-            li
-              a(href='http://peterkrantz.com/v11n/statsbudget-2013/', target='_blank') Statsbudgeten 2013 (Sweden)
-            li
-              a(href='http://bund.offenerhaushalt.de/', target='_blank') OffenerHaushalt.de (Germany)
-            li
-              a(href='http://cameroon.openspending.org', target='_blank') Cameroon Budget Inquirer
-            li
-              a(href='http://slovakia.openspending.org', target='_blank') Slovakia's Municipal Budgets
-            li
-              a(href='http://www.budgetstories.md', target='_blank') Budget Stories (Moldova)
+            a(href='http://www.budgetstories.md', target='_blank') Budget Stories (Moldova)


### PR DESCRIPTION
Removing .subheader class from heading elements. The .subheader class does not have any styles applied to it on this page

Changing "Tools and Projects" h2 header to h1 for SEO purposes

Updating all h3 elements to h2 as that is available now to do within the header hierarchy

Adding subtext under some headers

Changing `http://www.openspending.org` to `http://openspending.org` as the original was not resolving